### PR TITLE
Add license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "optunahub"
 description = "OptunaHub"
 readme = "README.md"
+license = {file = "LICENSE"}
 authors = [
   {name = "Optuna team"}
 ]


### PR DESCRIPTION
## Motivation

@not522 mentioned that pyproject.toml lacked `license` entry.

## Changes

- Add `license` like https://github.com/optuna/optuna/blob/f954e3529d81ae156a9e91d31b50c89b390a3f67/pyproject.toml#L9