### PR TITLE
Add API reference.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,4 +43,5 @@ Load the package you want from the OptunaHub registry as follows.
    :maxdepth: 2
    :caption: Contents:
 
+   reference
    faq

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1,0 +1,7 @@
+Reference
+=========
+
+.. automodule:: optunahub
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
## Motivation

The initial commit had API references, but they were removed during the development.

## Changes

Add `reference.rst`


Screenshots are as follows:

<img width="670" alt="image" src="https://github.com/optuna/optunahub/assets/3255979/78b94636-f071-4b35-b926-d77aab1f07aa">
<img width="1066" alt="image" src="https://github.com/optuna/optunahub/assets/3255979/be35c93e-6e46-4c8c-926b-ff8fda9758aa">
