### PR TITLE
Suppress logs in dependent library

### DIFF
--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import inspect
+import logging
 import os
 import shutil
 import sys
@@ -16,6 +17,10 @@ import optuna.version
 
 import optunahub
 from optunahub import _conf
+
+
+# Revert the log level to Python's default (i.e., WARNING) for the `ga4mp` package.
+logging.getLogger("ga4mp.ga4mp").setLevel(logging.WARNING)
 
 
 def _import_github_dir(


### PR DESCRIPTION
## Motivation

[`ga4mp.ga4mp` changes the logging level](https://github.com/adswerve/GA4-Measurement-Protocol-Python/blob/4663738f8f9575c0dbc8c47b9b95455483c6e5e3/ga4mp/ga4mp.py#L26) from WARNING (Python default) to INFO.
It outputs some unintended logs during optunahub usage.

## Changes

- Revert the log level of `ga4mp.ga4mp`.