### PR TITLE
Fix argument name in docstring

### DIFF
--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -240,7 +240,7 @@ def load_local_module(
     """Import a package from the local registry.
 
     Args:
-        package_name:
+        package:
             The package name to load.
         registry_root:
             The root directory of the registry.

--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -171,7 +171,7 @@ def load_module(
     `repo_name`.
 
     Args:
-        package_name:
+        package:
             The package name to load.
         repo_owner:
             The owner of the repository.


### PR DESCRIPTION
## Motivation

The argument name for `package` seems to be wrong.

## Changes

- Fix the argument name in the docstring.