### PR TITLE
Refactoring load module

### DIFF
--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -46,111 +46,6 @@ def _get_global_variable_from_outer_scopes(key: str, default: Any) -> Any:
     return default
 
 
-def _import_github_dir(
-    package: str,
-    repo_owner: str,
-    repo_name: str,
-    registry_root: str,
-    ref: str | None,
-    base_url: str,
-    force_reload: bool,
-    auth: Auth.Auth | None,
-) -> tuple[types.ModuleType, bool]:
-    """Import a package in a GitHub repository.
-       The loaded package name is set to `optunahub_registry.package.<package>`.
-
-    Args:
-        package:
-            The package name to load.
-        repo_owner:
-            The owner of the repository.
-        repo_name:
-            The name of the repository.
-        registry_root:
-            The root directory of the registry.
-            The default is "package".
-        ref:
-            The Git reference (branch, tag, or commit SHA) for the package.
-            If None, the default branch of the repository is used.
-        base_url:
-            The base URL for the GitHub API.
-        force_reload:
-            If `True`, the package will be downloaded from the repository.
-            Otherwise, the package cached in the local directory will be loaded
-            if available.
-        auth:
-            The authentication object for the GitHub API.
-
-    Returns:
-        The module object of the package and a boolean value indicating whether
-        the cached package is imported.
-    """
-
-    if registry_root:
-        dir_path = f"{registry_root}/{package}"
-    else:
-        dir_path = package
-
-    # If `ref` is `None`, we need to access the repository to identify the
-    # default branch regardless of the cache availability.
-    g: Github | None = None
-    if ref is None:
-        g = Github(auth=auth, base_url=base_url)
-        repo = g.get_repo(f"{repo_owner}/{repo_name}")
-        ref = ref if ref is not None else repo.default_branch
-
-    hostname = urlparse(base_url).hostname
-    if hostname is None:
-        raise ValueError(f"Invalid base URL: {base_url}")
-    cache_dir_prefix = os.path.join(_conf.cache_home(), hostname, repo_owner, repo_name, ref)
-    package_cache_dir = os.path.join(cache_dir_prefix, dir_path)
-    use_cache = not force_reload and os.path.exists(package_cache_dir)
-
-    if not use_cache:
-        if g is None:
-            g = Github(auth=auth, base_url=base_url)
-            repo = g.get_repo(f"{repo_owner}/{repo_name}")
-
-        package_contents = repo.get_contents(dir_path, ref)
-
-        if isinstance(package_contents, ContentFile):
-            package_contents = [package_contents]
-
-        shutil.rmtree(package_cache_dir, ignore_errors=True)
-        os.makedirs(cache_dir_prefix, exist_ok=True)
-        for m in package_contents:
-            file_path = os.path.join(cache_dir_prefix, m.path)
-            os.makedirs(os.path.dirname(file_path), exist_ok=True)
-            if m.type == "dir":
-                dir_contents = repo.get_contents(m.path, ref)
-                if isinstance(dir_contents, ContentFile):
-                    dir_contents = [dir_contents]
-                package_contents.extend(dir_contents)
-            else:
-                with open(file_path, "wb") as f:
-                    try:
-                        decoded_content = m.decoded_content
-                    except AssertionError:
-                        continue
-                    f.write(decoded_content)
-
-    module_path = os.path.join(cache_dir_prefix, dir_path)
-    module_name = f"optunahub_registry.package.{package.replace('/', '.')}"
-    spec = importlib.util.spec_from_file_location(
-        module_name, os.path.join(module_path, "__init__.py")
-    )
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Module {module_name} not found in {module_path}")
-    module = importlib.util.module_from_spec(spec)
-    if module is None:
-        raise ImportError(f"Module {module_name} not found in {module_path}")
-    setattr(module, "OPTUNAHUB_REF", ref)
-    setattr(module, "OPTUNAHUB_FORCE_RELOAD", force_reload)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module, use_cache
-
-
 def _report_stats(
     package: str,
     ref: str | None,
@@ -194,12 +89,13 @@ def load_module(
     repo_owner: str = "optuna",
     repo_name: str = "optunahub-registry",
     registry_root: str = "package",
-    ref: str | None = "main",
+    ref: str | None = None,
     base_url: str = "https://api.github.com",
     force_reload: bool | None = None,
     auth: Auth.Auth | None = None,
 ) -> types.ModuleType:
     """Import a package from the OptunaHub registry.
+    The imported package name is set to `optunahub_registry.package.<package>`.
     A third-party registry is also available by setting the `repo_owner` and
     `repo_name`.
 
@@ -215,6 +111,9 @@ def load_module(
             The default is "package".
         ref:
             The Git reference (branch, tag, or commit SHA) for the package.
+            This setting will be inherited to the inner `load`-like function.
+            If `None`, the setting is inherited from the outer `load`-like function.
+            For the outermost call, the default is `"main"`.
         base_url:
             The base URL for the GitHub API.
         force_reload:
@@ -235,15 +134,48 @@ def load_module(
         "OPTUNAHUB_FORCE_RELOAD", False
     )
 
-    module, is_cache = _import_github_dir(
+    dir_path = f"{registry_root}/{package}" if registry_root else package
+    hostname = urlparse(base_url).hostname
+    if hostname is None:
+        raise ValueError(f"Invalid base URL: {base_url}")
+    cache_dir_prefix = os.path.join(_conf.cache_home(), hostname, repo_owner, repo_name, ref)
+    package_cache_dir = os.path.join(cache_dir_prefix, dir_path)
+    use_cache = not force_reload and os.path.exists(package_cache_dir)
+
+    if not use_cache:
+        # Download package from GitHub.
+        g = Github(auth=auth, base_url=base_url)
+        repo = g.get_repo(f"{repo_owner}/{repo_name}")
+
+        package_contents = repo.get_contents(dir_path, ref)
+
+        if isinstance(package_contents, ContentFile):
+            package_contents = [package_contents]
+
+        shutil.rmtree(package_cache_dir, ignore_errors=True)
+        os.makedirs(cache_dir_prefix, exist_ok=True)
+        for m in package_contents:
+            file_path = os.path.join(cache_dir_prefix, m.path)
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            if m.type == "dir":
+                dir_contents = repo.get_contents(m.path, ref)
+                if isinstance(dir_contents, ContentFile):
+                    dir_contents = [dir_contents]
+                package_contents.extend(dir_contents)
+            else:
+                with open(file_path, "wb") as f:
+                    try:
+                        decoded_content = m.decoded_content
+                    except AssertionError:
+                        continue
+                    f.write(decoded_content)
+
+    local_registry_root = os.path.join(cache_dir_prefix, registry_root)
+    module = load_local_module(
         package=package,
-        repo_owner=repo_owner,
-        repo_name=repo_name,
-        registry_root=registry_root,
+        registry_root=local_registry_root,
         ref=ref,
-        base_url=base_url,
         force_reload=force_reload,
-        auth=auth,
     )
 
     # Statistics are collected only for the official registry.
@@ -252,7 +184,7 @@ def load_module(
         and repo_name == "optunahub-registry"
         and base_url == "https://api.github.com"
     )
-    if not _conf.is_no_analytics() and not is_cache and is_official_registry:
+    if not _conf.is_no_analytics() and not use_cache and is_official_registry:
         _report_stats(package, ref)
 
     return module
@@ -261,8 +193,8 @@ def load_module(
 def load_local_module(
     package: str,
     *,
-    ref: str | None = None,
     registry_root: str = os.sep,
+    ref: str | None = None,
     force_reload: bool | None = None,
 ) -> types.ModuleType:
     """Import a package from the local registry.

--- a/tests/package_for_test_hub/__init__.py
+++ b/tests/package_for_test_hub/__init__.py
@@ -1,3 +1,5 @@
+from optuna.samplers import RandomSampler
+
 import optunahub
 
 from . import implementation
@@ -9,4 +11,4 @@ force_reload = optunahub.hub._get_global_variable_from_outer_scopes(
 )
 
 
-__all__ = ["implementation", "ref", "force_reload"]
+__all__ = ["RandomSampler", "implementation", "ref", "force_reload"]

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,9 +1,43 @@
 import os
 import sys
 
+import optuna
 import pytest
 
 import optunahub
+
+
+def test_load_module() -> None:
+    def objective(trial: optuna.Trial) -> float:
+        x = trial.suggest_float("x", 0, 1)
+
+        return x
+
+    m = optunahub.load_module("samplers/simulated_annealing")
+    assert m.__name__ == "optunahub_registry.package.samplers.simulated_annealing"
+
+    # Confirm no error occurs by running optimization
+    sampler = m.SimulatedAnnealingSampler()
+    study = optuna.create_study(sampler=sampler)
+    study.optimize(objective, n_trials=10)
+
+
+def test_load_local_module() -> None:
+    def objective(trial: optuna.Trial) -> float:
+        x = trial.suggest_float("x", 0, 1)
+
+        return x
+
+    m = optunahub.load_local_module(
+        "package_for_test_hub",
+        registry_root=os.path.dirname(__file__),
+    )
+    assert m.__name__ == "optunahub_registry.package.package_for_test_hub"
+
+    # Confirm no error occurs by running optimization
+    sampler = m.RandomSampler()
+    study = optuna.create_study(sampler=sampler)
+    study.optimize(objective, n_trials=10)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Motivation
- Unify the implementation of module import functionality in `load_module` and `load_module_local`.

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes

Refactoring `load_module` as follows:
- First, download a target package from GitHub to the local cache directory.
- Then, call `load_local_module` to import the target module from the local cache.

Minor refactoring is also applied.
- Update doctring.
- To fix the inconsistency, change the order of the `ref` and `registry_root` arguments for `load_local_module`.