### PR TITLE
Fix format of inline code in the docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ pip install optunahub
 # Example
 
 ```python
-import optunahub
 import optuna
+import optunahub
 
 
 def objective(trial: optuna.Trial) -> float:
@@ -35,13 +35,10 @@ def objective(trial: optuna.Trial) -> float:
     return x
 
 
-if __name__ == "__main__":
-    mod = optunahub.load_module("samplers/simulated_annealing")
+mod = optunahub.load_module("samplers/simulated_annealing")
+study = optuna.create_study(sampler=mod.SimulatedAnnealingSampler())
+study.optimize(objective, n_trials=20)
 
-    sampler = mod.SimulatedAnnealingSampler()
-    study = optuna.create_study(sampler=sampler)
-    study.optimize(objective, n_trials=20)
-
-    print(study.best_trial.value, study.best_trial.params)
+print(study.best_trial.value, study.best_trial.params)
 
 ```

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -10,7 +10,7 @@ How to opt-out of the anonymous analytics?
 `OptunaHub collects anonymous usage data <https://hub.optuna.org/static/anonymous_analytics/>`__ to improve the service.
 The data is used to understand how users interact with the service and to identify areas for improvement.
 
-Youn can opt-out of the anonymous analytics by setting the environment variable `OPTUNAHUB_NO_ANALYTICS` to `1`
+Youn can opt-out of the anonymous analytics by setting the environment variable ``OPTUNAHUB_NO_ANALYTICS`` to ``1``.
 
 .. code-block:: shell
 
@@ -22,12 +22,12 @@ How to configure the package cache?
 
 OptunaHub caches the downloaded packages in the following locations.
 
-- The directory defined by `OPTUNAHUB_CACHE_HOME` environment variable
-- (UNIX-like) `XDG_CACHE_HOME/optunahub`
-- (Windows) `%LOCALAPPDATA%/optunahub`
+- The directory defined by ``OPTUNAHUB_CACHE_HOME`` environment variable
+- (UNIX-like) ``XDG_CACHE_HOME/optunahub``
+- (Windows) ``%LOCALAPPDATA%/optunahub``
 
 The settings are prioritized in the order listed above.
-`XDG_CACHE_HOME` is usually `~/.cache` on UNIX-like systems.
+``XDG_CACHE_HOME`` is usually ``~/.cache`` on UNIX-like systems.
 
 If you have any trouble with the cache, you can remove the cache directory to reset the cache.
 
@@ -35,7 +35,7 @@ If you have any trouble with the cache, you can remove the cache directory to re
 How can I update an OptunaHub package already cached?
 -----------------------------------------------------
 
-Calling `optunahub.load_module()` with `force_reload=True` ensures the selected package is re-download from the package registry.
+Calling ``optunahub.load_module()`` with ``force_reload=True`` ensures the selected package is re-download from the package registry.
 
 
 I got the "403: rate limit exceeded" error when loading a package. How can I fix it?

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 Welcome to OptunaHub's documentation!
 =====================================
 
-OptunaHub is a registry of third-party Optuna packages.
+`OptunaHub <https://hub.optuna.org/>`__ is a registry of third-party Optuna packages.
 It allows users to share and discover Optuna packages that are not included in the official Optuna distribution.
 The `optunahub <https://github.com/optuna/optunahub/>`_ library provides Python APIs to load and use packages from the OptunaHub registry.
 
@@ -9,7 +9,7 @@ The `optunahub <https://github.com/optuna/optunahub/>`_ library provides Python 
 Usage
 =====
 
-Install the `optunahub` package.
+Install the `optunahub`_ package.
 
 .. code-block:: shell
 
@@ -19,8 +19,8 @@ Load the package you want from the OptunaHub registry as follows.
 
 .. code-block:: python
 
-   import optunahub
    import optuna
+   import optunahub
 
 
    def objective(trial: optuna.Trial) -> float:
@@ -29,14 +29,12 @@ Load the package you want from the OptunaHub registry as follows.
       return x
 
 
-   if __name__ == "__main__":
-      mod = optunahub.load_module("samplers/simulated_annealing")
+   mod = optunahub.load_module("samplers/simulated_annealing")
 
-      sampler = mod.SimulatedAnnealingSampler()
-      study = optuna.create_study(sampler=sampler)
-      study.optimize(objective, n_trials=20)
+   study = optuna.create_study(sampler=mod.SimulatedAnnealingSampler())
+   study.optimize(objective, n_trials=20)
 
-      print(study.best_trial.value, study.best_trial.params)
+   print(study.best_trial.value, study.best_trial.params)
 
 
 .. toctree::

--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -95,9 +95,9 @@ def load_module(
     auth: Auth.Auth | None = None,
 ) -> types.ModuleType:
     """Import a package from the OptunaHub registry.
-    The imported package name is set to `optunahub_registry.package.<package>`.
-    A third-party registry is also available by setting the `repo_owner` and
-    `repo_name`.
+    The imported package name is set to ``optunahub_registry.package.<package>``.
+    A third-party registry is also available by setting the ``repo_owner`` and
+    ``repo_name``.
 
     Args:
         package:
@@ -112,15 +112,15 @@ def load_module(
         ref:
             The Git reference (branch, tag, or commit SHA) for the package.
             This setting will be inherited to the inner `load`-like function.
-            If `None`, the setting is inherited from the outer `load`-like function.
-            For the outermost call, the default is `"main"`.
+            If :obj:`None`, the setting is inherited from the outer `load`-like function.
+            For the outermost call, the default is "main".
         base_url:
             The base URL for the GitHub API.
         force_reload:
-            If `True`, the package will be downloaded from the repository.
-            If `False`, the package cached in the local directory will be
+            If :obj:`True`, the package will be downloaded from the repository.
+            If :obj:`False`, the package cached in the local directory will be
             loaded if available.
-            If `None`, the setting is inherited from the outer `load`-like function.
+            If :obj:`None`, the setting is inherited from the outer `load`-like function.
             For the outermost call, the default is `False`.
         auth:
             `The authentication object <https://pygithub.readthedocs.io/en/latest/examples/Authentication.html>`__ for the GitHub API.
@@ -198,7 +198,7 @@ def load_local_module(
     force_reload: bool | None = None,
 ) -> types.ModuleType:
     """Import a package from the local registry.
-       The imported package name is set to `optunahub_registry.package.<package>`.
+       The imported package name is set to ``optunahub_registry.package.<package>``.
 
     Args:
         package:
@@ -209,12 +209,12 @@ def load_local_module(
             e.g., "/" for UNIX-like systems.
         ref:
             This setting will be inherited to the inner `load`-like function.
-            If `None`, the setting is inherited from the outer `load`-like function.
-            For the outermost call, the default is `"main"`.
+            If :obj:`None`, the setting is inherited from the outer `load`-like function.
+            For the outermost call, the default is "main".
         force_reload:
             This setting will be inherited to the inner `load`-like function.
-            If `None`, the setting is inherited from the outer `load`-like function.
-            For the outermost call, the default is `False`.
+            If :obj:`None`, the setting is inherited from the outer `load`-like function.
+            For the outermost call, the default is :obj:`False`.
 
     Returns:
         The module object of the package.


### PR DESCRIPTION
## Motivation

We usually use double-backquotes for inline code blocks.
However, we can see single-backquoted code blocks in the tutorial.

## Description of the changes

- Fix the format of inline code
- `if __name__ == "__main__"` was removed from sample code in docs and README.