### PR TITLE
Fix CODECOV_TOKEN for upload

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,14 +64,15 @@ jobs:
         PYTHONPATH: .  # To invoke sitecutomize.py
         COVERAGE_PROCESS_START: .coveragerc  # https://coverage.readthedocs.io/en/6.4.1/subprocess.html
         COVERAGE_COVERAGE: yes  # https://github.com/nedbat/coveragepy/blob/65bf33fc03209ffb01bbbc0d900017614645ee7a/coverage/control.py#L255-L261
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
-        coverage run --source=optunahub -m pytest tests 
+        coverage run --source=optunahub -m pytest tests
         coverage combine
         coverage xml
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         file: ./coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
## Motivation

Since `CODECOV_TOKEN` is required to upload the coverage data, this environmental variable must be set in the "Upload coverage to Codecov" phase.

## Description of the changes

- Move `CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}` from "Tests" to "Upload coverage to Codecov".