### PR TITLE
Opt out analytics in CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,6 +64,7 @@ jobs:
         PYTHONPATH: .  # To invoke sitecutomize.py
         COVERAGE_PROCESS_START: .coveragerc  # https://coverage.readthedocs.io/en/6.4.1/subprocess.html
         COVERAGE_COVERAGE: yes  # https://github.com/nedbat/coveragepy/blob/65bf33fc03209ffb01bbbc0d900017614645ee7a/coverage/control.py#L255-L261
+        OPTUNAHUB_NO_ANALYTICS: 1
       run: |
         coverage run --source=optunahub -m pytest tests
         coverage combine

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -22,4 +22,6 @@ jobs:
           pip install --progress-bar off -U setuptools
           pip install --progress-bar off ".[test]"
       - name: Run Test
+        env:
+          OPTUNAHUB_NO_ANALYTICS: 1
         run: pytest tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-  
+
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python${{ matrix.python-version }}
@@ -25,4 +25,6 @@ jobs:
           pip install --progress-bar off -U setuptools
           pip install --progress-bar off ".[test]"
       - name: Run Test
+        env:
+          OPTUNAHUB_NO_ANALYTICS: 1
         run: pytest tests

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -22,4 +22,6 @@ jobs:
           pip install --progress-bar off -U setuptools
           pip install --progress-bar off ".[test]"
       - name: Run Test
+        env:
+          OPTUNAHUB_NO_ANALYTICS: 1
         run: pytest tests


### PR DESCRIPTION
## Motivation

We may want to avoid counting the package download during CI.

## Description of the changes

Set `OPTUNAHUB_NO_ANALYTICS="1"`