### PR TITLE
Introduce SimpleBaseSampler and remove load settings propagation

### DIFF
--- a/docs/source/optunahub.rst
+++ b/docs/source/optunahub.rst
@@ -1,0 +1,11 @@
+.. module:: optunahub
+
+optunahub
+=========
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   optunahub.load_module
+   optunahub.load_local_module

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1,7 +1,8 @@
 Reference
 =========
 
-.. automodule:: optunahub
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. toctree::
+    :maxdepth: 1
+
+    optunahub
+    samplers

--- a/docs/source/samplers.rst
+++ b/docs/source/samplers.rst
@@ -1,0 +1,10 @@
+.. module:: optunahub.samplers
+
+optunahub.samplers
+==================
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   optunahub.samplers.SimpleBaseSampler

--- a/optunahub/__init__.py
+++ b/optunahub/__init__.py
@@ -1,6 +1,7 @@
+from optunahub import samplers
 from optunahub.hub import load_local_module
 from optunahub.hub import load_module
 from optunahub.version import __version__
 
 
-__all__ = ["load_module", "load_local_module", "__version__"]
+__all__ = ["load_module", "load_local_module", "__version__", "samplers"]

--- a/optunahub/samplers/__init__.py
+++ b/optunahub/samplers/__init__.py
@@ -1,0 +1,4 @@
+from optunahub.samplers._simple_base import SimpleBaseSampler
+
+
+__all__ = ["SimpleBaseSampler"]

--- a/optunahub/samplers/_simple_base.py
+++ b/optunahub/samplers/_simple_base.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import abc
+from typing import Any
+
+from optuna import Study
+from optuna.distributions import BaseDistribution
+from optuna.samplers import BaseSampler
+from optuna.samplers import RandomSampler
+from optuna.search_space import IntersectionSearchSpace
+from optuna.trial import FrozenTrial
+
+
+class SimpleBaseSampler(BaseSampler, abc.ABC):
+    def __init__(
+        self, search_space: dict[str, BaseDistribution] | None = None, seed: int | None = None
+    ) -> None:
+        self.search_space = search_space
+        self._seed = seed
+        self._init_defaults()
+
+    def infer_relative_search_space(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+    ) -> dict[str, BaseDistribution]:
+        # This method is optional.
+        # If you want to optimize the function with the eager search space,
+        # please implement this method.
+        if self.search_space is not None:
+            return self.search_space
+        return self._default_infer_relative_search_space(study, trial)
+
+    @abc.abstractmethod
+    def sample_relative(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        search_space: dict[str, BaseDistribution],
+    ) -> dict[str, Any]:
+        # This method is required.
+        # This method is called at the beginning of each trial in Optuna to sample parameters.
+        raise NotImplementedError
+
+    def sample_independent(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        param_name: str,
+        param_distribution: BaseDistribution,
+    ) -> Any:
+        # This method is optional.
+        # By default, parameter values are sampled by ``optuna.samplers.RandomSampler``.
+        return self._default_sample_independent(study, trial, param_name, param_distribution)
+
+    def reseed_rng(self) -> None:
+        self._default_reseed_rng()
+
+    def _init_defaults(self) -> None:
+        self._intersection_search_space = IntersectionSearchSpace()
+        self._random_sampler = RandomSampler(seed=self._seed)
+
+    def _default_infer_relative_search_space(
+        self, study: Study, trial: FrozenTrial
+    ) -> dict[str, BaseDistribution]:
+        search_space: dict[str, BaseDistribution] = {}
+        for name, distribution in self._intersection_search_space.calculate(study).items():
+            if distribution.single():
+                # Single value objects are not sampled with the `sample_relative` method,
+                # but with the `sample_independent` method.
+                continue
+            search_space[name] = distribution
+        return search_space
+
+    def _default_sample_independent(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        param_name: str,
+        param_distribution: BaseDistribution,
+    ) -> Any:
+        # Following parameters are randomly sampled here.
+        # 1. A parameter in the initial population/first generation.
+        # 2. A parameter to mutate.
+        # 3. A parameter excluded from the intersection search space.
+
+        return self._random_sampler.sample_independent(
+            study, trial, param_name, param_distribution
+        )
+
+    def _default_reseed_rng(self) -> None:
+        self._random_sampler.reseed_rng()

--- a/optunahub/samplers/_simple_base.py
+++ b/optunahub/samplers/_simple_base.py
@@ -12,6 +12,8 @@ from optuna.trial import FrozenTrial
 
 
 class SimpleBaseSampler(BaseSampler, abc.ABC):
+    """A simple base class to implement user-defined samplers."""
+
     def __init__(
         self, search_space: dict[str, BaseDistribution] | None = None, seed: int | None = None
     ) -> None:

--- a/tests/package_for_test_hub/__init__.py
+++ b/tests/package_for_test_hub/__init__.py
@@ -1,4 +1,4 @@
-from optuna.samplers import RandomSampler
+from .sampler import TestSampler
 
 
-__all__ = ["RandomSampler"]
+__all__ = ["TestSampler"]

--- a/tests/package_for_test_hub/__init__.py
+++ b/tests/package_for_test_hub/__init__.py
@@ -1,14 +1,4 @@
 from optuna.samplers import RandomSampler
 
-import optunahub
 
-from . import implementation
-
-
-ref = optunahub.hub._get_global_variable_from_outer_scopes("OPTUNAHUB_REF", "main")
-force_reload = optunahub.hub._get_global_variable_from_outer_scopes(
-    "OPTUNAHUB_FORCE_RELOAD", False
-)
-
-
-__all__ = ["RandomSampler", "implementation", "ref", "force_reload"]
+__all__ = ["RandomSampler"]

--- a/tests/package_for_test_hub/implementation.py
+++ b/tests/package_for_test_hub/implementation.py
@@ -1,7 +1,0 @@
-import optunahub
-
-
-ref = optunahub.hub._get_global_variable_from_outer_scopes("OPTUNAHUB_REF", "main")
-force_reload = optunahub.hub._get_global_variable_from_outer_scopes(
-    "OPTUNAHUB_FORCE_RELOAD", False
-)

--- a/tests/package_for_test_hub/sampler.py
+++ b/tests/package_for_test_hub/sampler.py
@@ -19,8 +19,8 @@ class TestSampler(optunahub.samplers.SimpleBaseSampler):
         self,
         study: Study,
         trial: FrozenTrial,
-        search_space: dict[str, BaseDistribution],
-    ) -> dict[str, Any]:
+        search_space: Dict[str, BaseDistribution],
+    ) -> Dict[str, Any]:
         params = {}
         for n, d in search_space.items():
             params[n] = self._rng.uniform(d.low, d.high)

--- a/tests/package_for_test_hub/sampler.py
+++ b/tests/package_for_test_hub/sampler.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+import numpy as np
+from optuna import Study
+from optuna.distributions import BaseDistribution
+from optuna.trial import FrozenTrial
+
+import optunahub
+
+
+class TestSampler(optunahub.samplers.SimpleBaseSampler):
+    def __init__(self, search_space: dict[str, BaseDistribution] | None = None) -> None:
+        super().__init__(search_space)
+        self._rng = np.random.RandomState()
+
+    def sample_relative(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        search_space: dict[str, BaseDistribution],
+    ) -> dict[str, Any]:
+        params = {}
+        for n, d in search_space.items():
+            params[n] = self._rng.uniform(d.low, d.high)
+        return params

--- a/tests/package_for_test_hub/sampler.py
+++ b/tests/package_for_test_hub/sampler.py
@@ -1,4 +1,5 @@
 from typing import Any
+from typing import Dict
 from typing import Optional
 
 import numpy as np
@@ -10,7 +11,7 @@ import optunahub
 
 
 class TestSampler(optunahub.samplers.SimpleBaseSampler):
-    def __init__(self, search_space: Optional[dict[str, BaseDistribution]] = None) -> None:
+    def __init__(self, search_space: Optional[Dict[str, BaseDistribution]] = None) -> None:
         super().__init__(search_space)
         self._rng = np.random.RandomState()
 

--- a/tests/package_for_test_hub/sampler.py
+++ b/tests/package_for_test_hub/sampler.py
@@ -1,4 +1,5 @@
 from typing import Any
+from typing import Optional
 
 import numpy as np
 from optuna import Study
@@ -9,7 +10,7 @@ import optunahub
 
 
 class TestSampler(optunahub.samplers.SimpleBaseSampler):
-    def __init__(self, search_space: dict[str, BaseDistribution] | None = None) -> None:
+    def __init__(self, search_space: Optional[dict[str, BaseDistribution]] = None) -> None:
         super().__init__(search_space)
         self._rng = np.random.RandomState()
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,8 +1,6 @@
 import os
-import sys
 
 import optuna
-import pytest
 
 import optunahub
 
@@ -38,32 +36,3 @@ def test_load_local_module() -> None:
     sampler = m.RandomSampler()
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=10)
-
-
-@pytest.mark.parametrize(
-    ("ref", "force_reload", "expected_ref", "expected_force_reload"),
-    [
-        (None, None, "main", False),
-        ("main", False, "main", False),
-        ("test", True, "test", True),
-    ],
-)
-def test_load_settings_propagation(
-    ref: str,
-    force_reload: bool,
-    expected_ref: str,
-    expected_force_reload: bool,
-) -> None:
-    m = optunahub.load_local_module(
-        "package_for_test_hub",
-        registry_root=os.path.dirname(__file__),
-        ref=ref,
-        force_reload=force_reload,
-    )
-    assert m.ref == expected_ref
-    assert m.force_reload == expected_force_reload
-    assert m.implementation.ref == expected_ref
-    assert m.implementation.force_reload == expected_force_reload
-
-    del sys.modules["optunahub_registry.package.package_for_test_hub"]
-    del sys.modules["optunahub_registry.package.package_for_test_hub.implementation"]

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -33,6 +33,6 @@ def test_load_local_module() -> None:
     assert m.__name__ == "optunahub_registry.package.package_for_test_hub"
 
     # Confirm no error occurs by running optimization
-    sampler = m.RandomSampler()
+    sampler = m.TestSampler()
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=10)


### PR DESCRIPTION
## Motivation

We've decided to move `SimpleBaseSampler` from `optunahub-registry` to `optunahub.samplers` and remove settings propagation. This PR introduces `SimpleBaseSampler` and removes things that are no longer needed.

## Description of the changes

- Add `optunahub.samplers.SimpleBaseSampler`
- Add docs for `optunahub.samplers.SimpleBaseSampler`
- Remove code for settings propagation from `load_module` and `load_local_module`
- Remove tests for settings propagation