### PR TITLE
Remove license line in project section of `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "setuptools.build_meta"
 name = "optunahub"
 description = "OptunaHub"
 readme = "README.md"
-license = {file = "LICENSE"}
 authors = [
   {name = "Optuna team"}
 ]


### PR DESCRIPTION
## Motivation

In the metadata section of [pypi](https://pypi.org/project/optunahub/), the license of optunahub is fully shown.
I think this is because `pyproject.toml` imports the contents of the `LICENSE` file.
Instead, we can use 'classifiers' starting with `License ::` according to [Python packaging user guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license).

<img width="278" alt="image" src="https://github.com/user-attachments/assets/45e58d52-a5d7-444f-b877-cfc6064e65f1">

Optuna v3.0.0 used [only the classifiers](https://github.com/optuna/optuna/blob/cf09ea9327ce764afe8991fabcc65e7bfbd6d76c/setup.py#L198), but [pypi](https://pypi.org/project/optuna/3.0.0/) showed the metadata as expected.

<img width="241" alt="image" src="https://github.com/user-attachments/assets/3b58d383-5dd0-4336-b734-cf79ba9a59fe">


## Description of the changes

- Removed the `license` in `project`