### PR TITLE
Update development status to stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 ]
 dynamic = ["version"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Motivation

We'd like to change the development status from alpha to stable.
The classifier name can be found at https://pypi.org/classifiers/.

## Description of the changes

- Changed the development status in the classifiers.