### PR TITLE
Bump up version number to v0.2.0.dev

### DIFF
--- a/optunahub/version.py
+++ b/optunahub/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.0.dev"
+__version__ = "0.2.0.dev"


### PR DESCRIPTION
## Motivation

The code for v0.1.0 was frozen.
We want to update the version for optunahub development.

## Description of the changes

Change the version number from 0.1.0.dev to 0.2.0.dev.