### PR TITLE
Add minimum version for pygithub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.8"
 dependencies = [
   "ga4mp",
   "optuna",
-  "PyGithub",
+  "PyGithub>=1.59",
 ]
 dynamic = ["version"]
 classifiers = [


### PR DESCRIPTION
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The `Auth` module was introduced in v1.59:
- https://github.com/PyGithub/PyGithub/pull/2528
- https://github.com/PyGithub/PyGithub/releases/tag/v1.59.0

Using an earlier version will result in:
```
ImportError: cannot import name 'Auth' from 'github' 
```

when trying to import optunahub.

## Description of the changes
<!-- Describe the changes in this PR. -->
