### PR TITLE
Add link to optunahub-registry

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,6 +5,8 @@ Welcome to OptunaHub's documentation!
 It allows users to share and discover Optuna packages that are not included in the official Optuna distribution.
 The `optunahub <https://github.com/optuna/optunahub/>`_ library provides Python APIs to load and use packages from the OptunaHub registry.
 
+**If you are interested in registering your own features in OptunaHub**, please contribute them to `the optunahub-registry repository <https://github.com/optuna/optunahub-registry>`__. For more information, see `the optunahub-registry tutorial <https://optuna.github.io/optunahub-registry/>`__.
+
 
 Usage
 =====

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Welcome to OptunaHub's documentation!
 It allows users to share and discover Optuna packages that are not included in the official Optuna distribution.
 The `optunahub <https://github.com/optuna/optunahub/>`_ library provides Python APIs to load and use packages from the OptunaHub registry.
 
-**If you are interested in registering your own features in OptunaHub**, please contribute them to `the optunahub-registry repository <https://github.com/optuna/optunahub-registry>`__. For more information, see `the optunahub-registry tutorial <https://optuna.github.io/optunahub-registry/>`__.
+**If you are interested in registering your own features in OptunaHub**, please visit `the optunahub-registry repository <https://github.com/optuna/optunahub-registry>`__ and submit a pull request there. More details are available in `the optunahub-registry tutorial <https://optuna.github.io/optunahub-registry/>`__.
 
 
 Usage


### PR DESCRIPTION
## Motivation & Description of the changes

- Add links to optunahub-registry and its documentation from the optunahub docs.

<img width="737" alt="image" src="https://github.com/user-attachments/assets/8206b77f-c35e-4bad-a2df-c440e57800ca">
