### PR TITLE
Add auto-generated docs to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ ENV/
 
 # Sphinx
 docs/_build/
+docs/source/generated/


### PR DESCRIPTION
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The directory `./docs/source/generated` is used for auto-generated files during the build process and does not need to be tracked by Git.

## Description of the changes
<!-- Describe the changes in this PR. -->
I added the name of directory to `.gitignore`.
