### PR TITLE
Reduce API call limit error

### DIFF
--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -71,7 +71,7 @@ def load_module(
     repo_owner: str = "optuna",
     repo_name: str = "optunahub-registry",
     ref: str = "main",
-    base_url: str = "https://github.com",
+    base_url: str | None = None,
     force_reload: bool = False,
     auth: Auth.Auth | None = None,
 ) -> types.ModuleType:
@@ -114,19 +114,19 @@ def load_module(
     use_cache = not force_reload and os.path.exists(package_cache_dir)
 
     if not use_cache:
-        if auth is None:
+        if auth is None and shutil.which("git") is not None:
             _download_via_git(
                 repo_owner=repo_owner,
                 repo_name=repo_name,
                 dir_path=dir_path,
                 ref=ref,
-                base_url=base_url,
+                base_url=base_url or "https://github.com",
                 cache_dir_prefix=cache_dir_prefix,
             )
         else:
             _download_via_github_api(
                 auth=auth,
-                base_url=base_url,
+                base_url=base_url or "https://api.github.com",
                 repo_owner=repo_owner,
                 repo_name=repo_name,
                 dir_path=dir_path,

--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -90,23 +90,23 @@ def load_module(
         ref:
             The Git reference (branch, tag, or commit SHA) for the package.
         base_url:
-            If ``auth`` is :obj:`None`, the base URI for the remote repository.
-            In this case, specifying ``git@github.com`` allows access to private repositories via SSH.
-            If ``auth`` is not :obj:`None`, the base URL for the GitHub API.
+            If ``auth`` is :obj:`None` and the ``git`` command is available, the base URI for the remote repository.
+            In this case, specifying ``git@github.com`` allows access to private/internal repositories via SSH.
+            If ``auth`` is not :obj:`None` or the ``git`` command is not available, the base URL for the GitHub API.
         force_reload:
             If :obj:`True`, the package will be downloaded from the repository.
             If :obj:`False`, the package cached in the local directory will be
             loaded if available.
         auth:
             `The authentication object <https://pygithub.readthedocs.io/en/latest/examples/Authentication.html>`__ for the GitHub API.
-            It is required to access private/internal repositories via the GitHub API.
+            It also allows access to access private/internal repositories via the GitHub API.
 
     Returns:
         The module object of the package.
     """
     registry_root = "package"
     dir_path = f"{registry_root}/{package}"
-    hostname = _extract_hostname(base_url)
+    hostname = _extract_hostname(base_url) if base_url else "github.com"
     if hostname is None:
         raise ValueError(f"Invalid base URI: {base_url}")
     cache_dir_prefix = os.path.join(_conf.cache_home(), hostname, repo_owner, repo_name, ref)

--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -170,7 +170,9 @@ def _download_via_git(
     repo_url_separator = "/" if "://" in base_url else ":"
     repo_url = f"{base_url.rstrip('/')}{repo_url_separator}{repo_owner}/{repo_name}"
     repo = Repo.init(cache_dir_prefix)
-    origin = repo.create_remote("origin", repo_url)
+    origin = repo.remotes.origin if "origin" in repo.remotes else repo.create_remote("origin", repo_url)
+    if repo.remotes.origin.url != repo_url:
+        repo.remotes.origin.set_url(repo_url)
     repo.git.sparse_checkout("init", "--cone")
     repo.git.sparse_checkout("set", dir_path)
     origin.fetch(refspec=ref, depth=1)

--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -91,6 +91,7 @@ def load_module(
             The Git reference (branch, tag, or commit SHA) for the package.
         base_url:
             If ``auth`` is :obj:`None`, the base URI for the remote repository.
+            In this case, specifying ``git@github.com`` allows access to private repositories via SSH.
             If ``auth`` is not :obj:`None`, the base URL for the GitHub API.
         force_reload:
             If :obj:`True`, the package will be downloaded from the repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.8"
 dependencies = [
   "ga4mp",
   "optuna",
+  "GitPython",
   "PyGithub",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Currently, the `load_module` function often gets stuck due to [the rate limit for the GitHub REST API](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28).
The rate limit for unauthenticated requests is 60 requests per hour, which is very strict.

The error message looks like this:
```
Request GET /repos/optuna/optunahub-registry failed with 403: rate limit exceeded
INFO:github.GithubRetry:Request GET /repos/optuna/optunahub-registry failed with 403: rate limit exceeded
Setting next backoff to 3570.799172s
INFO:github.GithubRetry:Setting next backoff to 3570.799172s
```

## Description of the changes
<!-- Describe the changes in this PR. -->

- Use `git` command when available to avoid the rate limit.

## Benchmarking results

I benchmarked:
- How many times `samplers/auto_sampler` can be loaded within one minute
- The time it takes to load once

### Setups

The benchmark code I used here is as follows:
```py
!pip install optuna
# or
# !pip install git+https://github.com/kAIto47802/optunahub@reduce-api-call-limit

!pip install -q cmaes


import optuna
import optunahub
import time

start = time.time()
for i in range(500):
    mod = optunahub.load_module("samplers/auto_sampler", force_reload=True)
    print(i)
    end = time.time()
    print("end - start:", end - start)
    if end - start > 60:
        break

print("end - start:", end - start)
print("Number of iterations:", i)
```

The benchmarks were run five times for both the original and the new implementation.

I used a different Google Colaboratory notebook for each benchmarking run to ensure a different IP address was used every time. (Also, I confirmed the attached VM's IP address is certainly different by using the command `curl ifconfig.me`.)


### Results

The average number of times `load_module` was successfully executed without hitting the API rate limit is as follows:

|Original| This PR|
|---|---|
|5.2| - |

With the new implementation, running continuous downloads for one minute does not hit a rate limit across all five runs. (Therefore, it is indicated with a dash (–) in the table.)


The average time for downloading once is as follows:

|Original|This PR|
|---|---|
|4.50 ± 0.45 sec|0.49 ± 0.12 sec|

$m \pm \sigma$ indicates the average and the standard error over the five runs, respectively.



 
