### PR TITLE
Remove `ga4mp` to deploy in anaconda environment

### DIFF
--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -8,7 +8,8 @@ import shutil
 import sys
 import types
 from urllib.parse import urlparse
-from urllib.request import Request, urlopen
+from urllib.request import Request
+from urllib.request import urlopen
 
 from github import Auth
 from github import Github

--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -6,11 +6,9 @@ import json
 import os
 import shutil
 import sys
-import time
 import types
 from urllib.parse import urlparse
-from urllib.request import Request
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 from github import Auth
 from github import Github
@@ -64,8 +62,6 @@ def _report_stats(
                     "optunahub_version": optunahub.__version__,
                     "package": package,
                     "ref": ref,
-                    "session_id": int(time.time()),
-                    "engagement_time_msec": 0,
                 },
             }
         ],

--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import logging
 import os
 import shutil
 import sys
@@ -23,10 +22,6 @@ from optunahub import _conf
 
 # Dummy optunahub_registry module is required to avoid ModuleNotFoundError.
 sys.modules["optunahub_registry"] = types.ModuleType("optunahub_registry")
-
-
-# Revert the log level to Python's default (i.e., WARNING) for the `ga4mp` package.
-logging.getLogger("ga4mp.ga4mp").setLevel(logging.WARNING)
 
 
 def _report_stats(
@@ -88,9 +83,9 @@ def _report_stats(
         with urlopen(req) as response:
             status_code = response.status
             if status_code != 200:
-                print(f"Failed to send data. Status code: {status_code}")
+                print(f"Failed to send data. Status code: {status_code}", file=sys.stderr)
     except Exception as e:
-        print(f"Error occurred: {e}")
+        print(f"Error occurred: {e}", file=sys.stderr)
 
 
 def load_module(

--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import suppress
 import importlib.util
 import json
 import os
@@ -79,13 +80,9 @@ def _report_stats(
     }
 
     req = Request(url, data=json_data_as_bytes, headers=headers)
-    try:
-        with urlopen(req) as response:
-            status_code = response.status
-            if status_code != 200:
-                print(f"Failed to send data. Status code: {status_code}", file=sys.stderr)
-    except Exception as e:
-        print(f"Error occurred: {e}", file=sys.stderr)
+    with suppress(Exception):
+        with urlopen(req) as _:
+            pass
 
 
 def load_module(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ authors = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "ga4mp",
   "optuna",
   "PyGithub>=1.59",
 ]


### PR DESCRIPTION
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Use of the module `ga4mp` is not allowed in anaconda environment.
This prevents optunahub from being deployed in anaconda. 

## Description of the changes
<!-- Describe the changes in this PR. -->
I simply removed `GtagMP` which is used to send log to google analytics, and replaced it with `urllib`.