### PR TITLE
Fix the condition for stats report to count the default `load_module` stats

### DIFF
--- a/optunahub/_conf.py
+++ b/optunahub/_conf.py
@@ -31,11 +31,11 @@ def cache_home() -> str:
         )
 
 
-def is_no_analytics() -> bool | None:
+def is_no_analytics() -> bool:
     """Return whether the analytics is disabled.
 
     Returns:
-        `True` if the analytics is disabled, `False` if the analytics is enabled, or `None` if the configuration is not set.
+        `True` if the analytics is disabled, `False` if the analytics is enabled.
     """
 
     return os.getenv("OPTUNAHUB_NO_ANALYTICS", "0") == "1"

--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -136,11 +136,11 @@ def load_module(
     if not use_cache:
         if auth is None and shutil.which("git") is not None:
             _download_via_git(
+                base_url=base_url or "https://github.com",
                 repo_owner=repo_owner,
                 repo_name=repo_name,
                 dir_path=dir_path,
                 ref=ref,
-                base_url=base_url or "https://github.com",
                 cache_dir_prefix=cache_dir_prefix,
             )
         else:
@@ -162,11 +162,7 @@ def load_module(
     )
 
     # Statistics are collected only for the official registry.
-    is_official_registry = (
-        repo_owner == "optuna"
-        and repo_name == "optunahub-registry"
-        and base_url == "https://github.com"
-    )
+    is_official_registry = repo_owner == "optuna" and repo_name == "optunahub-registry"
     if not _conf.is_no_analytics() and not use_cache and is_official_registry:
         _report_stats(package, ref)
 
@@ -183,11 +179,11 @@ def _extract_hostname(url: str) -> str | None:
 
 
 def _download_via_git(
+    base_url: str,
     repo_owner: str,
     repo_name: str,
     dir_path: str,
     ref: str,
-    base_url: str,
     cache_dir_prefix: str,
 ) -> None:
     repo_url_separator = "/" if "://" in base_url else ":"

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -61,7 +61,7 @@ def test_extract_hostname(uri: str, expected_hostname: str) -> None:
 
 @pytest.mark.parametrize("git_command", ["/usr/bin/git", None])
 def test_if_report_stats_is_called(monkeypatch: MonkeyPatch, git_command: str | None) -> None:
-    def mock_do_nothing(*args, **kwargs) -> None:
+    def mock_do_nothing(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         return
 
     # To make the environment look like git is available or unavailable.
@@ -73,9 +73,7 @@ def test_if_report_stats_is_called(monkeypatch: MonkeyPatch, git_command: str | 
     monkeypatch.setattr("optunahub._conf.is_no_analytics", lambda: False)
 
     # Capture the call of _report_stats.
-    calls = []
-    monkeypatch.setattr(
-        "optunahub.hub._report_stats", lambda *args, **kwargs: calls.append(None)
-    )
+    calls: list[None] = []
+    monkeypatch.setattr("optunahub.hub._report_stats", lambda *args, **kwargs: calls.append(None))
     optunahub.load_module(package="dummy/test")
     assert len(calls) > 0

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -57,3 +57,25 @@ def test_load_local_module() -> None:
 )
 def test_extract_hostname(uri: str, expected_hostname: str) -> None:
     assert _extract_hostname(uri) == expected_hostname
+
+
+@pytest.mark.parametrize("git_command", ["/usr/bin/git", None])
+def test_if_report_stats_is_called(monkeypatch: MonkeyPatch, git_command: str | None) -> None:
+    def mock_do_nothing(*args, **kwargs) -> None:
+        return
+
+    # To make the environment look like git is available or unavailable.
+    monkeypatch.setattr(shutil, "which", lambda cmd: git_command)
+    monkeypatch.setattr("optunahub.hub._download_via_git", mock_do_nothing)
+    monkeypatch.setattr("optunahub.hub._download_via_github_api", mock_do_nothing)
+    monkeypatch.setattr("optunahub.hub.load_local_module", mock_do_nothing)
+    # Analytics must be activated.
+    monkeypatch.setattr("optunahub._conf.is_no_analytics", lambda: False)
+
+    # Capture the call of _report_stats.
+    calls = []
+    monkeypatch.setattr(
+        "optunahub.hub._report_stats", lambda *args, **kwargs: calls.append(None)
+    )
+    optunahub.load_module(package="dummy/test")
+    assert len(calls) > 0


### PR DESCRIPTION
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As the latest main branch does not count the stats for any default `load_module` calls, we fix this bug. 

## Description of the changes
<!-- Describe the changes in this PR. -->

- Change the setup
- Add the unit test for this