### PR TITLE
Add pytest timeout for GitHub API rate limits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ docs = [
 test = [
   "coverage",
   "pytest",
+  "pytest-timeout",
 ]
 
 [project.urls]

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -10,6 +10,7 @@ from pytest import MonkeyPatch
 import optunahub
 from optunahub.hub import _extract_hostname
 
+
 # NOTE(fusawa-yugo): Ensure the test fails quickly if GitHub API rate limits cause delays.
 @pytest.mark.parametrize("git_command", ["/usr/bin/git", None])
 @pytest.mark.timeout(120)

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -10,8 +10,9 @@ from pytest import MonkeyPatch
 import optunahub
 from optunahub.hub import _extract_hostname
 
-
+# NOTE(fusawa-yugo): Ensure the test fails quickly if GitHub API rate limits cause delays.
 @pytest.mark.parametrize("git_command", ["/usr/bin/git", None])
+@pytest.mark.timeout(120)
 def test_load_module(monkeypatch: MonkeyPatch, git_command: str | None) -> None:
     def objective(trial: optuna.Trial) -> float:
         x = trial.suggest_float("x", 0, 1)

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -13,7 +13,7 @@ from optunahub.hub import _extract_hostname
 
 # NOTE(fusawa-yugo): Ensure the test fails quickly if GitHub API rate limits cause delays.
 @pytest.mark.parametrize("git_command", ["/usr/bin/git", None])
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(600)
 def test_load_module(monkeypatch: MonkeyPatch, git_command: str | None) -> None:
     def objective(trial: optuna.Trial) -> float:
         x = trial.suggest_float("x", 0, 1)


### PR DESCRIPTION
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
CI tests sometimes hang due to GitHub API rate limits.  
To avoid this, I added a timeout using `pytest-timeout`.

## Description of the changes
<!-- Describe the changes in this PR. -->
The test raises error if it takes more than 120 seconds.

Error message is like below in python environment.
```bash
========================= short test summary info =========================
FAILED tests/test_hub.py::test_load_module[None] - Failed: Timeout (>120.0s) from pytest-timeout.
```

`pytest-timeout` package can be found in conda environment.
https://anaconda.org/anaconda/pytest-timeout

