### PR TITLE
Exclude `_download_via_github_api` from codecov

### DIFF
--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -210,7 +210,7 @@ def _download_via_git(
         shutil.move(os.path.join(tmpdir, dir_path), package_cache_dir)
 
 
-def _download_via_github_api(
+def _download_via_github_api(  # pragma: no cover
     auth: Auth.Auth | None,
     base_url: str,
     repo_owner: str,


### PR DESCRIPTION
## Motivation & Description of the changes
The test for `_download_via_github_api` is intentionally excluded because it causes CI to stack up, so we also exclude this function from the code coverage calculation.