### PR TITLE
Fix release CI

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -26,6 +26,9 @@ jobs:
       with:
         python-version: 3.11
 
+    - name: Create venv
+      run: uv venv
+
     - name: Install twine
       run: |
         uv pip install -U twine wheel build


### PR DESCRIPTION
## Motivation & Description of the changes

Fix https://github.com/optuna/optunahub/actions/runs/23908068418/job/69722278810#logs.

```sh
Run uv pip install -U twine wheel build
error: No virtual environment found for Python 3.11; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment
Error: Process completed with exit code 2.
```