### PR TITLE
Pinned every action for pypi-publish to a commit SHA

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -20,9 +20,9 @@ jobs:
     if: github.repository == 'optuna/optunahub'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Setup uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
         python-version: 3.11
 
@@ -57,17 +57,11 @@ jobs:
     - name: Publish distribution to TestPyPI
       # The following upload action cannot be executed in the forked repository.
       if: (github.event_name == 'schedule') || (github.event_name == 'release')
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
       with:
         repository-url: https://test.pypi.org/legacy/
 
     - name: Publish distribution to PyPI
       # The following upload action cannot be executed in the forked repository.
       if: github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        # Temporary workaround to bypass Twine's bug with attestation support
-        # See https://github.com/pypa/gh-action-pypi-publish/issues/283
-        # TODO(c-bata): Once a new version of twine is released, delete this line.
-        # https://github.com/pypa/twine/pull/1172
-        attestations: false
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0


### PR DESCRIPTION
## Motivation & Description of the changes

For security, pin every action for pypi-publish to a commit SHA.

