### PR TITLE
Disable attestations

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -68,6 +68,4 @@ jobs:
       with:
         # Temporary workaround to bypass Twine's bug with attestation support
         # See https://github.com/pypa/gh-action-pypi-publish/issues/283
-        # TODO(y0z): Once a new version of twine is released, delete this line.
-        # https://github.com/pypa/twine/pull/1172
         attestations: false

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -65,3 +65,9 @@ jobs:
       # The following upload action cannot be executed in the forked repository.
       if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+      with:
+        # Temporary workaround to bypass Twine's bug with attestation support
+        # See https://github.com/pypa/gh-action-pypi-publish/issues/283
+        # TODO(y0z): Once a new version of twine is released, delete this line.
+        # https://github.com/pypa/twine/pull/1172
+        attestations: false


### PR DESCRIPTION
## Motivation & Description of the changes

Because the attestation issue persists, we disable the setting again.