### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+.github/ @optuna/optuna-core
+


### PR DESCRIPTION
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This change is inspired by TanStack's recent incident report, which highlights the security risks associated with GitHub workflows:

> Putting CODEOWNERS on .github folders, restricting workflow changes to core maintainers. We're leaning toward "yes" on this one; workflow files are code that runs with our credentials, and that means they should be treated like the most privileged code in the repo, because that's effectively what they are.
> https://tanstack.com/blog/incident-followup

## Description of the changes
<!-- Describe the changes in this PR. -->
- Added `CODEOWNERS` protection to the `.github/` folder to restrict workflow and configuration changes to designated maintainers.