### PR TITLE
Remove stats

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -4,19 +4,6 @@ FAQ
 .. contents::
     :local:
 
-How to opt-out of the anonymous analytics?
-------------------------------------------
-
-`OptunaHub collects anonymous usage data <https://hub.optuna.org/static/anonymous_analytics/>`__ to improve the service.
-The data is used to understand how users interact with the service and to identify areas for improvement.
-
-You can opt-out of the anonymous analytics by setting the environment variable ``OPTUNAHUB_NO_ANALYTICS`` to ``1``.
-
-.. code-block:: shell
-
-      export OPTUNAHUB_NO_ANALYTICS=1
-
-
 How to configure the package cache?
 -----------------------------------
 

--- a/optunahub/_conf.py
+++ b/optunahub/_conf.py
@@ -29,13 +29,3 @@ def cache_home() -> str:
             os.getenv("XDG_CACHE_HOME", os.path.join(os.path.expanduser("~"), ".cache")),
             "optunahub",
         )
-
-
-def is_no_analytics() -> bool:
-    """Return whether the analytics is disabled.
-
-    Returns:
-        `True` if the analytics is disabled, `False` if the analytics is enabled.
-    """
-
-    return os.getenv("OPTUNAHUB_NO_ANALYTICS", "0") == "1"

--- a/optunahub/hub.py
+++ b/optunahub/hub.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from contextlib import suppress
 import importlib.util
-import json
 import os
 import re
 import shutil
@@ -10,79 +8,17 @@ import sys
 import tempfile
 import types
 from urllib.parse import urlparse
-from urllib.request import Request
-from urllib.request import urlopen
 
 from git import Repo
 from github import Auth
 from github import Github
 from github.ContentFile import ContentFile
-import optuna.version
 
-import optunahub
 from optunahub import _conf
 
 
 # Dummy optunahub_registry module is required to avoid ModuleNotFoundError.
 sys.modules["optunahub_registry"] = types.ModuleType("optunahub_registry")
-
-
-def _report_stats(
-    package: str,
-    ref: str | None,
-) -> None:
-    """Report anonymous statistics.
-
-    Collecting statistics for the official registry.
-    The following parameters are collected:
-      - CI: Whether the environment is CI or not.
-      - optuna_version: The version of Optuna.
-      - optunahub_version: The version of OptunaHub.
-      - package: The package name loaded.
-      - ref: The Git reference (branch, tag, or commit SHA) for the package.
-    WE NEVER COLLECT ANY PERSONAL INFORMATION.
-
-    The statistics can be disabled by setting the environmental variable OPTUNAHUB_NO_ANALYTICS=1,
-
-    Args:
-        package:
-            The package name loaded.
-        ref:
-            The Git reference (branch, tag, or commit SHA) for the package.
-    """
-    measurement_id = "G-8EZ4F4Z74E"
-    api_secret = "8tWYGaAEQJiYJSUJfqNMTw"
-    client_id = "optunahub"  # Anonymous (by always setting client_id to "optunahub")
-
-    url = f"https://www.google-analytics.com/mp/collect?measurement_id={measurement_id}&api_secret={api_secret}"
-    data = {
-        "client_id": client_id,
-        "events": [
-            {
-                "name": "load_module",
-                "params": {
-                    "CI": os.getenv("CI", False),
-                    "optuna_version": optuna.version.__version__,
-                    "optunahub_version": optunahub.__version__,
-                    "package": package,
-                    "ref": ref,
-                },
-            }
-        ],
-    }
-
-    jsondata = json.dumps(data)
-    json_data_as_bytes = jsondata.encode("utf-8")  # needs to be bytes
-
-    headers = {
-        "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": str(len(json_data_as_bytes)),
-    }
-
-    req = Request(url, data=json_data_as_bytes, headers=headers)
-    with suppress(Exception):
-        with urlopen(req) as _:
-            pass
 
 
 def load_module(
@@ -160,11 +96,6 @@ def load_module(
         package=package,
         registry_root=local_registry_root,
     )
-
-    # Statistics are collected only for the official registry.
-    is_official_registry = repo_owner == "optuna" and repo_name == "optunahub-registry"
-    if not _conf.is_no_analytics() and not use_cache and is_official_registry:
-        _report_stats(package, ref)
 
     return module
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -63,23 +63,3 @@ def test_load_local_module() -> None:
 )
 def test_extract_hostname(uri: str, expected_hostname: str) -> None:
     assert _extract_hostname(uri) == expected_hostname
-
-
-@pytest.mark.parametrize("git_command", ["/usr/bin/git", None])
-def test_if_report_stats_is_called(monkeypatch: MonkeyPatch, git_command: str | None) -> None:
-    def mock_do_nothing(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
-        return
-
-    # To make the environment look like git is available or unavailable.
-    monkeypatch.setattr(shutil, "which", lambda cmd: git_command)
-    monkeypatch.setattr("optunahub.hub._download_via_git", mock_do_nothing)
-    monkeypatch.setattr("optunahub.hub._download_via_github_api", mock_do_nothing)
-    monkeypatch.setattr("optunahub.hub.load_local_module", mock_do_nothing)
-    # Analytics must be activated.
-    monkeypatch.setattr("optunahub._conf.is_no_analytics", lambda: False)
-
-    # Capture the call of _report_stats.
-    calls: list[None] = []
-    monkeypatch.setattr("optunahub.hub._report_stats", lambda *args, **kwargs: calls.append(None))
-    optunahub.load_module(package="dummy/test")
-    assert len(calls) > 0


### PR DESCRIPTION
## Motivation & Description of the changes

We have decided not to collect package stats anymore; therefore, we are removing `_report_stats`.
