### PR TITLE
Use `set_constraint` in `BaseProblem`

### DIFF
--- a/docs/source/tutorials_for_users/how_to_use_benchmarks.rst
+++ b/docs/source/tutorials_for_users/how_to_use_benchmarks.rst
@@ -80,11 +80,8 @@ Constrained Problem
 ^^^^^^^^^^^^^^^^^^^
 
 Some benchmarks also include constraints.
-These problems are implemented by inheriting :class:`~optunahub.benchmarks.ConstrainedMixin` class.
-:class:`~optunahub.benchmarks.ConstrainedMixin` provides :meth:`~optunahub.benchmarks.ConstrainedMixin.evaluate_constraints` and :meth:`~optunahub.benchmarks.ConstrainedMixin.constraints_func` methods.
-As same as objective functions, :meth:`~optunahub.benchmarks.ConstrainedMixin.constraints_func` takes an :class:`optuna.Trial` object, while :meth:`~optunahub.benchmarks.ConstrainedMixin.evaluate_constraints` takes a dictionary of input parameters.
-Those methods are used to evaluate the constraint functions.
-You can optimize these problems in the same way as usual, but you need to set the ``constraints_func`` argument in the sampler.
+These problems implement the :meth:`~optunahub.benchmarks.BaseProblem.evaluate_constraints` method, which takes a dictionary of input parameters and returns a dictionary of constraint values.
+:class:`~optunahub.benchmarks.BaseProblem` sets those values to each trial, so you can optimize these problems in the same way as usual.
 
 .. code-block:: python
 
@@ -96,10 +93,7 @@ You can optimize these problems in the same way as usual, but you need to set th
     constrained_sphere2d = bbob_constrained.Problem(function_id=1, dimension=2, instance_id=1)
 
     study = optuna.create_study(
-        sampler=optuna.samplers.TPESampler(
-            constraints_func=constrained_sphere2d.constraints_func,
-            seed=42
-        ),
+        sampler=optuna.samplers.TPESampler(seed=42),
         directions=constrained_sphere2d.directions
     )
     study.optimize(constrained_sphere2d, n_trials=100)

--- a/optunahub/benchmarks/_base_problem.py
+++ b/optunahub/benchmarks/_base_problem.py
@@ -4,8 +4,24 @@ from abc import ABCMeta
 from abc import abstractmethod
 from typing import Any
 from typing import Sequence
+import warnings
 
 import optuna
+
+
+def _as_constraints_dict(constraints: dict[str, float] | Sequence[float]) -> dict[str, float]:
+    if isinstance(constraints, dict):
+        return constraints
+    # `evaluate_constraints` used to return a sequence. Such a return value is still accepted
+    # and each value is named by its index, which is the same naming as the one Optuna uses
+    # for the constraints stored in the old format.
+    warnings.warn(
+        "Returning a sequence from `evaluate_constraints` is deprecated in v0.5.0. "
+        "The benchmark package cached in your local directory is outdated. "
+        "Please update it by `optunahub.load_module(..., force_reload=True)`.",
+        FutureWarning,
+    )
+    return {str(i): value for i, value in enumerate(constraints)}
 
 
 class BaseProblem(metaclass=ABCMeta):
@@ -23,6 +39,11 @@ class BaseProblem(metaclass=ABCMeta):
         for name, dist in self.search_space.items():
             params[name] = trial._suggest(name, dist)
             trial._check_distribution(name, dist)
+        constraints = _as_constraints_dict(self.evaluate_constraints(params))
+        if constraints and not hasattr(trial, "set_constraint"):
+            raise RuntimeError("`evaluate_constraints` requires Optuna v5.0.0 or newer.")
+        for key, value in constraints.items():
+            trial.set_constraint(key, value)
         return self.evaluate(params)
 
     def evaluate(self, params: dict[str, Any]) -> float | Sequence[float]:
@@ -79,3 +100,35 @@ class BaseProblem(metaclass=ABCMeta):
                     return [optuna.study.StudyDirection.MINIMIZE]
         """
         ...
+
+    def evaluate_constraints(self, params: dict[str, Any]) -> dict[str, float]:
+        """Evaluate the constraint functions.
+
+        Args:
+            params: Dictionary of input parameters.
+        Returns:
+            Dictionary of the constraint values keyed by the constraint names.
+            A trial is considered feasible when all the values are zero or less.
+        """
+        return {}
+
+    def constraints_func(self, trial: optuna.trial.FrozenTrial) -> Sequence[float]:
+        """Evaluate the constraint functions.
+
+        .. warning::
+            Deprecated in v0.5.0. This feature will be removed in the future without prior notice.
+
+        Args:
+            trial: Optuna trial object.
+        Returns:
+            List of the constraint values.
+        """
+        warnings.warn(
+            "`constraints_func` is deprecated in v0.5.0 since OptunaHub's problems now set the "
+            "constraint values to each trial by themselves. Please stop passing "
+            "`constraints_func` to your sampler.",
+            FutureWarning,
+        )
+
+        constraints = self.evaluate_constraints(trial.params.copy())  # type: ignore[attr-defined]
+        return list(_as_constraints_dict(constraints).values())

--- a/optunahub/benchmarks/_constrained_mixin.py
+++ b/optunahub/benchmarks/_constrained_mixin.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any
-
-import optuna
-
 
 class ConstrainedMixin:
     """Mixin class for constrained optimization problems.
+
+    .. warning::
+        Deprecated in v0.5.0. This feature will be removed in the future without prior notice.
 
     Example:
         You can define a constrained optimization problem by inheriting this class and implementing
@@ -56,23 +54,3 @@ class ConstrainedMixin:
             study = optuna.create_study(sampler=sampler, directions=problem.directions)
             study.optimize(problem, n_trials=20)
     """
-
-    def constraints_func(self, trial: optuna.trial.FrozenTrial) -> Sequence[float]:
-        """Evaluate the constraint functions.
-
-        Args:
-            trial: Optuna trial object.
-        Returns:
-            List of the constraint values.
-        """
-        return self.evaluate_constraints(trial.params.copy())
-
-    def evaluate_constraints(self, params: dict[str, Any]) -> Sequence[float]:
-        """Evaluate the constraint functions.
-
-        Args:
-            params: Dictionary of input parameters.
-        Returns:
-            List of the constraint values.
-        """
-        raise NotImplementedError

--- a/recipes/007_benchmarks_advanced.py
+++ b/recipes/007_benchmarks_advanced.py
@@ -34,9 +34,15 @@ class DynamicProblem(BaseProblem):
         if x < 0:
             # Parameter `y` exists only when `x` is negative.
             y = trial.suggest_float("y", -5, 5)
-            return x**2 + y
+            value = x**2 + y
         else:
-            return x**2
+            value = x**2
+
+        # Call this after all the parameters are suggested so that ``trial.params`` is complete.
+        for key, constraint in self.evaluate_constraints(trial.params).items():
+            trial.set_constraint(key, constraint)
+
+        return value
 
     @property
     def directions(self) -> list[optuna.study.StudyDirection]:
@@ -70,14 +76,8 @@ study.optimize(dynamic_problem, n_trials=20)
 # -------------------------------------------------
 # Here, let's implement a problem with constraints.
 # To implement a problem with constraints, you need to implement the ``evaluate_constraints`` method, which evaluates the constraint functions given a dictionary of input parameters and returns a dictionary of constraint values.
-# The default ``__call__`` of ``BaseProblem`` sets them to the trial via ``optuna.trial.Trial.set_constraint``, but we have to do it by ourselves here since we override ``__call__``.
+# As ``DynamicProblem.__call__`` already sets the constraint values to the trial, we do not have to override ``__call__`` here.
 class ConstrainedProblem(DynamicProblem):
-    def __call__(self, trial: optuna.Trial) -> float:
-        value = super().__call__(trial)
-        for key, constraint in self.evaluate_constraints(trial.params).items():
-            trial.set_constraint(key, constraint)
-        return value
-
     def evaluate_constraints(self, params: dict[str, float]) -> dict[str, float]:
         x = params["x"]
         c0 = x - 2

--- a/recipes/007_benchmarks_advanced.py
+++ b/recipes/007_benchmarks_advanced.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import optuna
 
 from optunahub.benchmarks import BaseProblem
-from optunahub.benchmarks import ConstrainedMixin
 
 
 ###################################################################################################
@@ -70,30 +69,30 @@ study.optimize(dynamic_problem, n_trials=20)
 # Implementing a problem with constraints
 # -------------------------------------------------
 # Here, let's implement a problem with constraints.
-# To implement a problem with constraints, you need to inherit ``ConstrainedMixin`` class in addition to ``BaseProblem`` and implement the ``evaluate_constraints`` method.
-# The ``evaluate_constraints`` method evaluates the constraint functions given a dictionary of input parameters and returns a list of constraint values.
-# Then, ``ConstrainedMixin`` internally defines the ``constraints_func`` method for Optuna samplers.
-class ConstrainedProblem(ConstrainedMixin, DynamicProblem):
-    def evaluate_constraints(self, params: dict[str, float]) -> tuple[float, float]:
+# To implement a problem with constraints, you need to implement the ``evaluate_constraints`` method, which evaluates the constraint functions given a dictionary of input parameters and returns a dictionary of constraint values.
+# The default ``__call__`` of ``BaseProblem`` sets them to the trial via ``optuna.trial.Trial.set_constraint``, but we have to do it by ourselves here since we override ``__call__``.
+class ConstrainedProblem(DynamicProblem):
+    def __call__(self, trial: optuna.Trial) -> float:
+        value = super().__call__(trial)
+        for key, constraint in self.evaluate_constraints(trial.params).items():
+            trial.set_constraint(key, constraint)
+        return value
+
+    def evaluate_constraints(self, params: dict[str, float]) -> dict[str, float]:
         x = params["x"]
         c0 = x - 2
         if "y" not in params:
             c1 = 0.0  # c1 <= 0, so c1 is satisfied in this case.
-            return c0, c1
         else:
             y = params["y"]
             c1 = x + y - 3
-            return c0, c1
+        return {"c0": c0, "c1": c1}
 
 
 ###################################################################################################
 # Then, you can optimize the problem with Optuna as usual.
-# Don't forget to set the `constraints_func` argument to the sampler to use.
 problem = ConstrainedProblem()
-sampler = optuna.samplers.TPESampler(
-    constraints_func=problem.constraints_func
-)  # Pass the constraints_func to the sampler.
-study = optuna.create_study(sampler=sampler, directions=problem.directions)
+study = optuna.create_study(directions=problem.directions)
 study.optimize(problem, n_trials=20)
 
 ###################################################################################################

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import optuna
-from optuna.samplers._base import _CONSTRAINTS_KEY
 
 import optunahub
 
@@ -26,16 +25,15 @@ def test_base_problem() -> None:
     study.optimize(problem, n_trials=20)  # verify no error occurs
 
 
-def test_constrained_mixin() -> None:
-    class ConstrainedTestProblem(optunahub.benchmarks.ConstrainedMixin, TestProblem):
-        def evaluate_constraints(self, params: dict[str, float]) -> list[float]:
-            return [params["x"]]
+def test_constrained_problem() -> None:
+    class ConstrainedTestProblem(TestProblem):
+        def evaluate_constraints(self, params: dict[str, float]) -> dict[str, float]:
+            return {"c0": params["x"]}
 
     problem = ConstrainedTestProblem()
-    sampler = optuna.samplers.TPESampler(constraints_func=problem.constraints_func)
-    study = optuna.create_study(sampler=sampler, directions=problem.directions)
+    study = optuna.create_study(directions=problem.directions)
     study.optimize(problem, n_trials=20)  # verify no error occurs
 
     # Check if constraints are stored in trials
     for t in study.trials:
-        assert _CONSTRAINTS_KEY in study._storage.get_trial_system_attrs(t._trial_id)
+        assert t.constraints == {"c0": t.params["x"]}


### PR DESCRIPTION
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
With the introduction of new APIs for constrained optimization, OptunaHub will also adopt them.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Changed the return type of `evaluate_constraints` to `dict`, moving it from `ConstrainedMixin` to `BaseProblem`
- Marked `ConstrainedMixin` and `constraints_func` as deprecated
- Updated documentation

## Compatibility

| OptunaHub  | Package | User Code | Behavior |
| - | - | - | - |
| New | New | New | ✅  |
| New | New | Old | Constraints set twice |
| New | Old | New | ✅ with warning |
| New | Old | Old | Constraints set twice |
| Old | New | New | Raise `ValueError` |
| Old | New | Old | Raise `ValueError` |
| Old | Old | New | No constraints set |
| Old | Old | Old | ✅  |
